### PR TITLE
Add a .gitignore file that ignores _build and misc/__pycache__/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build/
+misc/__pycache__/


### PR DESCRIPTION
Just a small thing, but this is where stuff ends up when `make html` is run, and it seems nicer not to commit this sort of transient stuff, generally.